### PR TITLE
Fix player movement left/right

### DIFF
--- a/atascaburrasProject_fixed/src/system/game_system.asm
+++ b/atascaburrasProject_fixed/src/system/game_system.asm
@@ -29,9 +29,10 @@ UpdateGameSystem::
     ld a, JOY_SELECT_DPAD
     ld [rJOYP], a
     ld a, [rJOYP]
+    ld b, a                     ; Guarda el valor de entrada para pruebas
 
     ; Move left if pressed (bit cleared)
-    bit 1, a
+    bit 1, b
     jr nz, .check_right
     ld hl, PlayerX
     ld a, [hl]
@@ -40,7 +41,7 @@ UpdateGameSystem::
 
 .check_right:
     ; Move right if pressed (bit cleared)
-    bit 0, a
+    bit 0, b
     jr nz, .done
     ld hl, PlayerX
     ld a, [hl]


### PR DESCRIPTION
## Summary
- handle left/right movement correctly by preserving JOYP input value

## Testing
- `make` *(fails: rgbasm missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f8a500c8330a5e52989cc2b8139