### PR TITLE
Fix boot header and update map

### DIFF
--- a/atascaburrasProject_fixed/src/header.asm
+++ b/atascaburrasProject_fixed/src/header.asm
@@ -1,4 +1,31 @@
 SECTION "Header", ROM0[$100]
     nop
     jp Start
+
+NintendoLogo:
+    ; Official Nintendo logo required by the boot ROM
+    db $CE,$ED,$66,$66,$CC,$0D,$00,$0B
+    db $03,$73,$00,$83,$00,$0C,$00,$0D
+    db $00,$08,$11,$1F,$88,$89,$00,$0E
+    db $DC,$CC,$6E,$E6,$DD,$DD,$D9,$99
+    db $BB,$BB,$67,$63,$6E,$0E,$EC,$CC
+    db $DD,$DC,$99,$9F,$BB,$B9,$33,$3E
+
+GameTitle:
+    db "UNDERFLOW",0,0,0,0,0,0,0
+
+    ; Cartridge type, ROM size and other header bytes
+    db $00            ; CGB flag
+    db $00,$00        ; New licensee code
+    db $00            ; SGB flag
+    db $00            ; Cartridge type (ROM only)
+    db $00            ; ROM size (32KB)
+    db $00            ; RAM size (none)
+    db $01            ; Destination code (non-Japanese)
+    db $33            ; Old licensee code use new licensee
+    db $00            ; Mask ROM version
+    db $00            ; Header checksum (fixed later)
+    dw $0000          ; Global checksum (fixed later)
+
+    ; Pad the header up to $150
     ds $150 - @

--- a/atascaburrasProject_fixed/src/ui/maps.asm
+++ b/atascaburrasProject_fixed/src/ui/maps.asm
@@ -25,10 +25,55 @@ MACRO ROW_EXIT
     DB MT_WALL
 ENDM
 
+; Row with a horizontal wall leaving a gap on the left
+MACRO ROW_BAR_LEFT
+    DB MT_WALL
+    DB MT_FLOOR
+    REPT MAP_WIDTH - 3
+        DB MT_WALL
+    ENDR
+    DB MT_WALL
+ENDM
+
+; Row with a horizontal wall leaving a gap on the right
+MACRO ROW_BAR_RIGHT
+    DB MT_WALL
+    REPT MAP_WIDTH - 3
+        DB MT_WALL
+    ENDR
+    DB MT_FLOOR
+    DB MT_WALL
+ENDM
+
+; Bottom row with the exit in the bottom-right corner
+MACRO ROW_EXIT_CORNER
+    DB MT_WALL
+    REPT MAP_WIDTH - 2
+        DB MT_FLOOR
+    ENDR
+    DB MT_EXIT
+ENDM
+
 ; ----- Map 1 -----
 Map1:
-    ROW_WALLS
-    REPT MAP_HEIGHT - 2
-        ROW_EMPTY
-    ENDR
-    ROW_EXIT
+    ; Top border
+    ROW_WALLS      ; row 0
+    ; Player starts on row 1, column 1
+    ROW_EMPTY      ; row 1
+    ROW_BAR_RIGHT  ; row 2
+    ROW_EMPTY      ; row 3
+    ROW_BAR_LEFT   ; row 4
+    ROW_EMPTY      ; row 5
+    ROW_BAR_RIGHT  ; row 6
+    ROW_EMPTY      ; row 7
+    ROW_BAR_LEFT   ; row 8
+    ROW_EMPTY      ; row 9
+    ROW_BAR_RIGHT  ; row 10
+    ROW_EMPTY      ; row 11
+    ROW_BAR_LEFT   ; row 12
+    ROW_EMPTY      ; row 13
+    ROW_BAR_RIGHT  ; row 14
+    ROW_EMPTY      ; row 15
+    ROW_BAR_LEFT   ; row 16
+    ; Bottom row with the exit in the corner
+    ROW_EXIT_CORNER ; row 17


### PR DESCRIPTION
## Summary
- add Nintendo logo and header fields so the boot ROM continues
- create a simple maze-like Map1 with an exit in the bottom-right corner

## Testing
- `make clean && make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab54b73f88330b644f40f06f4caef