### PR TITLE
Fix map pointer access for collision detection

### DIFF
--- a/atascaburrasProject_fixed/src/system/game_system.asm
+++ b/atascaburrasProject_fixed/src/system/game_system.asm
@@ -179,10 +179,7 @@ GetTileAt:
     ld e, b
     add hl, de
     ; Add map base pointer
-    ld hl, CurrentMapPtr
-    ld e, [hl]
-    inc hl
-    ld d, [hl]
+    ld de, (CurrentMapPtr)
     add hl, de
     ld a, [hl]
     pop de


### PR DESCRIPTION
## Summary
- fix GetTileAt to correctly reference the current map

## Testing
- `make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac9f41cec8330b1905b41a390b447