### PR TITLE
Add second map and transition

### DIFF
--- a/atascaburrasProject_fixed/src/main.asm
+++ b/atascaburrasProject_fixed/src/main.asm
@@ -6,8 +6,8 @@ INCLUDE "src/ui/maps.asm"
 
 SECTION "Main", ROM0
 Start::
-    call InitRender
     call InitGameSystem
+    call InitRender
 
 MainLoop:
     call UpdateGameSystem

--- a/atascaburrasProject_fixed/src/system/game_system.asm
+++ b/atascaburrasProject_fixed/src/system/game_system.asm
@@ -134,6 +134,25 @@ UpdateDone:
     call GetTileAt
     cp MT_EXIT
     jr nz, UpdateReturn
+    ld hl, MapIndex
+    ld a, [hl]
+    or a
+    jr nz, .win_game
+    inc a
+    ld [hl], a            ; MapIndex ← 1
+    ld hl, Map2
+    ld a, l
+    ld [CurrentMapPtr], a
+    ld a, h
+    ld [CurrentMapPtr+1], a
+    ld a, 1
+    ld [PlayerX], a
+    ld [PlayerPrevX], a
+    ld [PlayerY], a
+    ld [PlayerPrevY], a
+    call DrawMap
+    jr UpdateReturn
+.win_game:
     ld a, 1
     ld [GameOver], a
 UpdateReturn:

--- a/atascaburrasProject_fixed/src/ui/maps.asm
+++ b/atascaburrasProject_fixed/src/ui/maps.asm
@@ -91,3 +91,24 @@ Map1:
 
     ROW_VBAR         ; fila 15: muro vertical
     ROW_EXIT_CORNER  ; fila 16: salida en la esquina inferior derecha
+
+EXPORT Map2
+
+Map2:
+    ROW_WALLS
+    ROW_BAR_RIGHT
+    ROW_VBAR
+    ROW_BAR_LEFT
+    ROW_VBAR
+    ROW_BAR_RIGHT
+    ROW_VBAR
+    ROW_EMPTY
+    ROW_VBAR
+    ROW_BAR_LEFT
+    ROW_VBAR
+    ROW_BAR_RIGHT
+    ROW_VBAR
+    ROW_BAR_LEFT
+    ROW_VBAR
+    ROW_EMPTY
+    ROW_EXIT_CORNER

--- a/atascaburrasProject_fixed/src/utils/render.asm
+++ b/atascaburrasProject_fixed/src/utils/render.asm
@@ -8,6 +8,7 @@ EXPORT TilesEnd
 
 EXPORT InitRender
 EXPORT RenderFrame
+EXPORT DrawMap
 
 
 WaitVBlankStart:
@@ -51,7 +52,10 @@ CopyTiles:
 
     ; Draw initial map in the background
     ld hl, $9800
-    ld de, Map1
+    ld a, [CurrentMapPtr]
+    ld e, a
+    ld a, [CurrentMapPtr+1]
+    ld d, a
     ld b, MAP_HEIGHT
 RowLoop:
     ld c, MAP_WIDTH
@@ -96,8 +100,11 @@ RenderFrame::
     ld a, [PlayerPrevX]
     ld e, a
     ld d, 0
-    add hl, de               ; HL = Map1 offset
-    ld de, Map1
+    add hl, de               ; HL = tile offset
+    ld a, [CurrentMapPtr]
+    ld e, a
+    ld a, [CurrentMapPtr+1]
+    ld d, a
     add hl, de
     ld b, [hl]               ; B = original tile
 
@@ -146,4 +153,30 @@ RenderFrame::
     add hl, de
     ld a, MT_PLAYER
     ld [hl], a              ; draw player tile
+    ret
+
+; Draws the current map pointed by CurrentMapPtr to the background
+DrawMap::
+    ld hl, $9800
+    ld a, [CurrentMapPtr]
+    ld e, a
+    ld a, [CurrentMapPtr+1]
+    ld d, a
+    ld b, MAP_HEIGHT
+.RowLoop:
+    ld c, MAP_WIDTH
+.ColLoop:
+    ld a, [de]
+    inc de
+    ld [hl+], a
+    dec c
+    jr nz, .ColLoop
+    ld a, l
+    add a, $20 - MAP_WIDTH
+    ld l, a
+    ld a, h
+    adc a, 0
+    ld h, a
+    dec b
+    jr nz, .RowLoop
     ret


### PR DESCRIPTION
## Summary
- design a new Map2 with more obstacles
- display maps via `CurrentMapPtr`
- add `DrawMap` helper and use it when swapping maps
- start game system before rendering
- load Map2 when reaching the exit of Map1

## Testing
- `make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b497753c083308240ea9cc61e2fdd