### PR TITLE
Fix map transition trigger at bottom-right corner

### DIFF
--- a/atascaburrasProject_fixed/src/system/game_system.asm
+++ b/atascaburrasProject_fixed/src/system/game_system.asm
@@ -126,7 +126,17 @@ CheckDown:
     ld [hl], a
 
 UpdateDone:
-    ; Check if player reached the exit tile
+    ; If the player reaches the bottom-right corner, switch maps
+    ld a, [PlayerX]
+    cp MAP_WIDTH-1
+    jr nz, .check_exit
+    ld a, [PlayerY]
+    cp MAP_HEIGHT-1
+    jr nz, .check_exit
+    jr .change_map
+
+.check_exit:
+    ; Otherwise, check if the tile is an explicit exit
     ld a, [PlayerX]
     ld b, a
     ld a, [PlayerY]
@@ -134,6 +144,8 @@ UpdateDone:
     call GetTileAt
     cp MT_EXIT
     jr nz, UpdateReturn
+
+.change_map:
     ld hl, MapIndex
     ld a, [hl]
     or a

--- a/atascaburrasProject_fixed/src/ui/maps.asm
+++ b/atascaburrasProject_fixed/src/ui/maps.asm
@@ -90,7 +90,8 @@ Map1:
     ROW_EMPTY        ; fila 14: CORREDOR LIBRE  ← antes ROW_VBAR
 
     ROW_VBAR         ; fila 15: muro vertical
-    ROW_EXIT_CORNER  ; fila 16: salida en la esquina inferior derecha
+    ROW_VBAR         ; fila 16: muro vertical
+    ROW_EXIT_CORNER  ; fila 17: salida en la esquina inferior derecha
 
 EXPORT Map2
 
@@ -111,4 +112,5 @@ Map2:
     ROW_BAR_LEFT
     ROW_VBAR
     ROW_EMPTY
+    ROW_VBAR
     ROW_EXIT_CORNER


### PR DESCRIPTION
## Summary
- check for reaching map limits before testing exit tile
- jump to new map when player hits bottom-right corner

## Testing
- `make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4dbd92248330b80b7c274198c0bd