### PR TITLE
Fix exit tile location in map

### DIFF
--- a/atascaburrasProject_fixed/src/ui/maps.asm
+++ b/atascaburrasProject_fixed/src/ui/maps.asm
@@ -47,11 +47,13 @@ ENDM
 
 ; Bottom row with the exit in the bottom-right corner
 MACRO ROW_EXIT_CORNER
+    ; Bottom boundary with exit shifted one tile left
     DB MT_WALL
-    REPT MAP_WIDTH - 2
+    REPT MAP_WIDTH - 3
         DB MT_FLOOR
     ENDR
     DB MT_EXIT
+    DB MT_FLOOR
 ENDM
 
 ; Row with a vertical wall in the middle (column 10)


### PR DESCRIPTION
## Summary
- move the exit tile one step left so it can be reached

## Testing
- `make clean && make` *(fails: rgbasm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b548426ec8330b57c3eaa85cce223