### PR TITLE
Fix exit tile position

### DIFF
--- a/atascaburrasProject_fixed/src/ui/maps.asm
+++ b/atascaburrasProject_fixed/src/ui/maps.asm
@@ -47,13 +47,12 @@ ENDM
 
 ; Bottom row with the exit in the bottom-right corner
 MACRO ROW_EXIT_CORNER
-    ; Bottom boundary with exit shifted one tile left
+    ; Bottom boundary with the exit in the bottom-right corner
     DB MT_WALL
-    REPT MAP_WIDTH - 3
+    REPT MAP_WIDTH - 2
         DB MT_FLOOR
     ENDR
     DB MT_EXIT
-    DB MT_FLOOR
 ENDM
 
 ; Row with a vertical wall in the middle (column 10)


### PR DESCRIPTION
## Summary
- update exit row macro so the exit sits at the lower-right corner

## Testing
- `make` *(fails: rgbasm missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b571d7e74833093a7d6b470e834f2