### PR TITLE
Fix map switch when player stands left of exit

### DIFF
--- a/atascaburrasProject_fixed/src/system/game_system.asm
+++ b/atascaburrasProject_fixed/src/system/game_system.asm
@@ -135,9 +135,22 @@ UpdateDone:
     jr nz, .check_exit
     jr .change_map
 
+
 .check_exit:
     ; Otherwise, check if the tile is an explicit exit
     ld a, [PlayerX]
+    ld b, a
+    ld a, [PlayerY]
+    ld c, a
+    call GetTileAt
+    cp MT_EXIT
+    jr z, .change_map
+
+    ; Additionally, switch maps when standing to the left of an exit tile
+    ld a, [PlayerX]
+    cp MAP_WIDTH-1            ; Ensure within bounds
+    jr z, UpdateReturn
+    inc a                     ; check tile to the right
     ld b, a
     ld a, [PlayerY]
     ld c, a


### PR DESCRIPTION
## Summary
- add new map transition logic if player stands left of an exit tile

## Testing
- `make -C atascaburrasProject_fixed clean && make -C atascaburrasProject_fixed` *(fails: `rgbasm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5c171cc083308e540bcb496c47fa