### PR TITLE
Fix Map2 to require more complex path

### DIFF
--- a/atascaburrasProject_fixed/src/ui/maps.asm
+++ b/atascaburrasProject_fixed/src/ui/maps.asm
@@ -126,19 +126,19 @@ EXPORT Map2
 
 Map2:
     ROW_WALLS
-    ROW_BAR_RIGHT
+    ROW_BAR_LEFT         ; apertura en la izquierda
+    ROW_EMPTY            ; permite cruzar horizontalmente
+    ROW_EMPTY            ; pasillo sin muro
     ROW_VBAR
-    ROW_BAR_LEFT
-    ROW_VBAR
-    ROW_BAR_RIGHT
+    ROW_BAR_RIGHT        ; hueco por la derecha
     ROW_VBAR
     ROW_EMPTY
     ROW_VBAR
     ROW_BAR_LEFT
     ROW_VBAR
-    ROW_BAR_RIGHT
-    ROW_VBAR
-    ROW_BAR_LEFT
+    ROW_BAR_LEFT         ; mantiene el corredor
+    ROW_EMPTY            ; cruce central
+    ROW_BAR_RIGHT        ; obliga a ir a la derecha
     ROW_VBAR
     ROW_EMPTY
     ROW_VBAR_RIGHT_GAP


### PR DESCRIPTION
## Summary
- reshape Map2 so the player must weave between left and right paths
- add gaps on the right and close the straight corridor

## Testing
- `make all` *(fails: `rgbasm` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b638531ec8330951607d179b62030