### PR TITLE
Fix VRAM updates on map change

### DIFF
--- a/atascaburrasProject_fixed/src/utils/render.asm
+++ b/atascaburrasProject_fixed/src/utils/render.asm
@@ -158,6 +158,7 @@ RenderFrame::
 
 ; Draws the current map pointed by CurrentMapPtr to the background
 DrawMap::
+    call WaitVBlankStart
     ld hl, $9800
     ld a, [CurrentMapPtr]
     ld e, a


### PR DESCRIPTION
## Summary
- wait for vblank before drawing a new map

## Testing
- `make -C atascaburrasProject_fixed` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855678c546c8330a92321287b3dd503