### PR TITLE
Fix render.asm syntax

### DIFF
--- a/atascaburrasProject_fixed/src/utils/render.asm
+++ b/atascaburrasProject_fixed/src/utils/render.asm
@@ -73,17 +73,23 @@ RenderFrame::
     ld l, a
     ld h, 0
     ; DE = y*4
-    sla l : rl h
-    sla l : rl h
+    sla l
+    rl h
+    sla l
+    rl h
     ld d, h
     ld e, l
     ; HL = y*16 (shift 4 veces)
     ld l, a
     ld h, 0
-    sla l : rl h
-    sla l : rl h
-    sla l : rl h
-    sla l : rl h
+    sla l
+    rl h
+    sla l
+    rl h
+    sla l
+    rl h
+    sla l
+    rl h
     add hl, de            ; HL = y*20
     ; añadir x
     ld a, [PlayerPrevX]
@@ -107,11 +113,16 @@ RenderFrame::
     ld l, a
     ld h, 0
     ; HL = y*32 (shift 5 veces)
-    sla l : rl h
-    sla l : rl h
-    sla l : rl h
-    sla l : rl h
-    sla l : rl h
+    sla l
+    rl h
+    sla l
+    rl h
+    sla l
+    rl h
+    sla l
+    rl h
+    sla l
+    rl h
     ; añadir x
     ld a, [PlayerX]
     ld e, a
@@ -141,7 +152,7 @@ DrawMap::
 RowLoop::
     ld c, MAP_WIDTH
 ColLoop::
-    ld a, [e]
+    ld a, [de]
     inc e
     ld [hl+], a
     dec c


### PR DESCRIPTION
## Summary
- split shift-and-rotate operations into separate instructions
- correct operand for reading map data

## Testing
- `make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582e5736188330b0a05b0b926d6937