### PR TITLE
Modify win handling

### DIFF
--- a/atascaburrasProject_fixed/src/main.asm
+++ b/atascaburrasProject_fixed/src/main.asm
@@ -19,6 +19,8 @@ MainLoop:
     jp MainLoop
 
 Win:
-    call DisplayWinMessage
+    call StopMusic
+    call ApplyWinPalette
+    call PlayWinJingle
 End:
     jr End ; halt on game completion

--- a/atascaburrasProject_fixed/src/system/audio_system.asm
+++ b/atascaburrasProject_fixed/src/system/audio_system.asm
@@ -4,6 +4,8 @@ SECTION "AudioSystem", ROM0
 
 EXPORT InitAudioSystem
 EXPORT UpdateAudioSystem
+EXPORT PlayWinJingle
+EXPORT StopMusic
 
 ; Internal routine to play the current note
 PlayCurrentNote:
@@ -77,3 +79,59 @@ NoteSequence:
     db $06, $07, 16  ; C5
     db $59, $07, 16  ; G5
 DEF NumNotes = 8
+
+;--------------------------------------------------
+; Stops currently playing music
+StopMusic:
+    xor a
+    ld [rNR52], a
+    ret
+
+;--------------------------------------------------
+; Simple victory jingle
+PlayWinJingle:
+    ld a, $80
+    ld [rNR52], a          ; enable sound
+    ld a, $77
+    ld [rNR50], a          ; max volume
+    ld a, $FF
+    ld [rNR51], a          ; route all channels
+
+    ld a, %11000000        ; 75% duty
+    ld [rNR21], a
+    ld a, $F1              ; volume envelope
+    ld [rNR22], a
+
+    ; First note
+    ld a, $C3
+    ld [rNR23], a
+    ld a, $87
+    ld [rNR24], a
+    ld b, 120
+.w1:
+    dec b
+    jr nz, .w1
+
+    ; Second note
+    ld a, $D6
+    ld [rNR23], a
+    ld a, $86 | $80
+    ld [rNR24], a
+    ld b, 120
+.w2:
+    dec b
+    jr nz, .w2
+
+    ; Third note
+    ld a, $E8
+    ld [rNR23], a
+    ld a, $85 | $80
+    ld [rNR24], a
+    ld b, 120
+.w3:
+    dec b
+    jr nz, .w3
+
+    xor a
+    ld [rNR52], a          ; stop sound
+    ret

--- a/atascaburrasProject_fixed/src/utils/constants.asm
+++ b/atascaburrasProject_fixed/src/utils/constants.asm
@@ -3,6 +3,7 @@ DEF rLCDC = $FF40
 DEF rSCX  = $FF43
 DEF rSCY  = $FF42
 DEF rJOYP = $FF00
+DEF rBGP  = $FF47
 
 ; Joypad bits and select mask
 DEF JOY_RIGHT      = $01
@@ -24,6 +25,10 @@ DEF TILE_W = $07
 DEF TILE_I = $08
 DEF TILE_N = $09
 DEF PLAYER_MOVE_DELAY = 8
+
+; Palette values
+DEF DEFAULT_PALETTE = $E4
+DEF WIN_PALETTE     = $1B
 
 ; Sound registers
 DEF rNR52 = $FF26

--- a/atascaburrasProject_fixed/src/utils/render.asm
+++ b/atascaburrasProject_fixed/src/utils/render.asm
@@ -10,6 +10,7 @@ EXPORT InitRender
 EXPORT RenderFrame
 EXPORT DrawMap
 EXPORT DisplayWinMessage
+EXPORT ApplyWinPalette
 
 
 WaitVBlankStart:
@@ -33,6 +34,9 @@ SwitchOnScreen:
 ; Initializes tile data and screen settings
 InitRender::
     call SwitchOffScreen
+
+    ld a, DEFAULT_PALETTE
+    ld [rBGP], a
 
     ld a, [rLCDC]
     set 4, a                      ; use $8000 tile data
@@ -219,3 +223,9 @@ DisplayWinMessage::
 WinMessage:
     db TILE_Y, TILE_O, TILE_U, MT_FLOOR, TILE_W, TILE_I, TILE_N
 DEF WinMessageLen = @-WinMessage
+
+; Apply a different palette when the player wins
+ApplyWinPalette:
+    ld a, WIN_PALETTE
+    ld [rBGP], a
+    ret


### PR DESCRIPTION
## Summary
- set default and victory palettes
- add win palette function
- add simple win jingle audio
- stop music and play win jingle when the player wins

## Testing
- `make clean && make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584b9e09788330beb34747d64ae047