### PR TITLE
Improve victory state

### DIFF
--- a/atascaburrasProject_fixed/src/main.asm
+++ b/atascaburrasProject_fixed/src/main.asm
@@ -19,6 +19,17 @@ MainLoop:
     jp MainLoop
 
 Win:
-    call DisplayWinMessage
-End:
-    jr End ; halt on game completion
+    call StartWinState
+WinLoop:
+    call UpdateAudioSystem
+    jr WinLoop
+
+StartWinState:
+    ld a, [WinStarted]
+    or a
+    ret nz
+    call SetWinPalette
+    call StartWinMusic
+    ld a, 1
+    ld [WinStarted], a
+    ret

--- a/atascaburrasProject_fixed/src/system/game_system.asm
+++ b/atascaburrasProject_fixed/src/system/game_system.asm
@@ -23,6 +23,7 @@ InitGameSystem::
     xor a
     ld [GameOver], a
     ld [MoveCooldown], a
+    ld [WinStarted], a
 
     ret
 

--- a/atascaburrasProject_fixed/src/utils/constants.asm
+++ b/atascaburrasProject_fixed/src/utils/constants.asm
@@ -3,6 +3,7 @@ DEF rLCDC = $FF40
 DEF rSCX  = $FF43
 DEF rSCY  = $FF42
 DEF rJOYP = $FF00
+DEF rBGP  = $FF47
 
 ; Joypad bits and select mask
 DEF JOY_RIGHT      = $01
@@ -24,6 +25,9 @@ DEF TILE_W = $07
 DEF TILE_I = $08
 DEF TILE_N = $09
 DEF PLAYER_MOVE_DELAY = 8
+
+DEF PALETTE_DEFAULT = $E4
+DEF PALETTE_WIN     = $1B
 
 ; Sound registers
 DEF rNR52 = $FF26

--- a/atascaburrasProject_fixed/src/utils/memory.asm
+++ b/atascaburrasProject_fixed/src/utils/memory.asm
@@ -12,6 +12,9 @@ EXPORT GameOver
 EXPORT MoveCooldown
 EXPORT CurrentNoteIndex
 EXPORT NoteTimer
+EXPORT WinStarted
+EXPORT CurrentSequencePtr
+EXPORT CurrentNumNotes
 
 ; Variables stored in WRAM cannot contain initialised data.
 ; Reserve the required space and initialise them at runtime instead.
@@ -25,3 +28,6 @@ GameOver:      ds 1
 MoveCooldown:  ds 1
 CurrentNoteIndex: ds 1
 NoteTimer:  ds 1
+WinStarted: ds 1
+CurrentSequencePtr: ds 2
+CurrentNumNotes: ds 1

--- a/atascaburrasProject_fixed/src/utils/render.asm
+++ b/atascaburrasProject_fixed/src/utils/render.asm
@@ -10,6 +10,7 @@ EXPORT InitRender
 EXPORT RenderFrame
 EXPORT DrawMap
 EXPORT DisplayWinMessage
+EXPORT SetWinPalette
 
 
 WaitVBlankStart:
@@ -33,6 +34,9 @@ SwitchOnScreen:
 ; Initializes tile data and screen settings
 InitRender::
     call SwitchOffScreen
+
+    ld a, PALETTE_DEFAULT
+    ld [rBGP], a
 
     ld a, [rLCDC]
     set 4, a                      ; use $8000 tile data
@@ -219,3 +223,8 @@ DisplayWinMessage::
 WinMessage:
     db TILE_Y, TILE_O, TILE_U, MT_FLOOR, TILE_W, TILE_I, TILE_N
 DEF WinMessageLen = @-WinMessage
+
+SetWinPalette::
+    ld a, PALETTE_WIN
+    ld [rBGP], a
+    ret


### PR DESCRIPTION
## Summary
- add palette constants and default/win colors
- store music sequence info in WRAM
- update audio system to allow a victory jingle
- reset `WinStarted` on game init
- change main loop to show victory palette and play jingle
- initialise and switch palettes in render system

## Testing
- `make clean && make` *(fails: rgbasm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584d317ff88330adff4cb05018fca7